### PR TITLE
Use date YYYYMMDD as version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,16 +33,17 @@ jobs:
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get latest cacher release
-        uses: armbian/actions/latest-cache@main
-
-      - name: Increment cache number
+      - name: Calc ROOTFSCACHE_VERSION
         id: env-vars
         run: |
 
+          ROOTFSCACHE_VERSION=$(date --utc +"%Y%m%d")
+
           mkdir -p rootfscache
-          echo "${{ env.ROOTFSCACHE_VERSION }}" | tee rootfscache/version
-          echo ::set-output name=rootfscache_version::$(echo ${{ env.ROOTFSCACHE_VERSION }}) || true
+          echo "${ROOTFSCACHE_VERSION}" | tee rootfscache/version
+
+          echo "ROOTFSCACHE_VERSION=${ROOTFSCACHE_VERSION}" >> $GITHUB_ENV
+          echo ::set-output name=rootfscache_version::${ROOTFSCACHE_VERSION} || true
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This maybe cause some problems if we build more than one time in a day. But it seem like `ncipollo/release-action` set `replacesArtifacts=true` by default. So maybe it can work well?

This PR has a advantage. If we are debuging the cache, we only bump 1 version at most in a day. So users only need to download or generate rootfs cache once in a day instand of as many as the time we try to run Action.